### PR TITLE
cable.ymlコメントアウト

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -9,9 +9,9 @@ test:
   adapter: test
 
 production:
-  adapter: solid_cable
-  connects_to:
-    database:
-      writing: cable
-  polling_interval: 0.1.seconds
-  message_retention: 1.day
+  #adapter: solid_cable
+  #connects_to:
+  #  database:
+   #   writing: cable
+  #polling_interval: 0.1.seconds
+  #message_retention: 1.day


### PR DESCRIPTION
### 内容
デプロイエラー
`/opt/render/project/.gems/ruby/3.2.0/gems/activerecord-7.0.8.6/lib/active_record/database_configurations.rb:177:in `resolve_symbol_connection': The `cable` database is not configured for the `production` environment. (ActiveRecord::AdapterNotSpecified)
`
解決のためcable.ymlをコメントアウトした