### PR TITLE
production.rbコメントアウト

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,8 +50,8 @@ Rails.application.configure do
   config.cache_store = :solid_cache_store
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
-  config.active_job.queue_adapter = :solid_queue
-  config.solid_queue.connects_to = { database: { writing: :queue } }
+  #config.active_job.queue_adapter = :solid_queue
+  #config.solid_queue.connects_to = { database: { writing: :queue } }
 
 
   # Ignore bad email addresses and do not raise email delivery errors.


### PR DESCRIPTION
### 内容
デプロイエラー解決のため
config/production.rb
`#config.active_job.queue_adapter = :solid_queue
  #config.solid_queue.connects_to = { database: { writing: :queue } }
`
をコメントアウトした